### PR TITLE
Fix rustc-josh-sync push command argument order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A pull operation fetches changes to the subtree subdirectory that were performed
 A push operation takes changes performed in the subtree repository and merges them into the subtree subdirectory of the `rust-lang/rust` repository. After performing a push, a push request is sent against the *rustc repository*. We *push to rustc*.
 
 1) Checkout the latest default branch of the subtree
-2) Run `rustc-josh-sync push <your-github-username> <branch>`
+2) Run `rustc-josh-sync push <branch> <your-github-username>`
     - The branch with the push contents will be created in `https://github.com/<your-github-username>/rust` fork, in the `<branch>` branch.
 3) Send a PR to [rust-lang/rust]
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation in `README.md` to clarify the usage of the `rustc-josh-sync push` command. The order of the `<branch>` and `<your-github-username>` arguments has been corrected to reflect the actual command syntax.

### Code reference:
```rust
    /// Push changes into the main `rust-lang/rust` repository `branch` of a `rustc` fork under
    /// the given GitHub `username`.
    /// The pushed branch should then be merged into the `rustc` repository.
    Push {
        /// Path to the josh-sync TOML config file.
        #[clap(long, default_value(DEFAULT_CONFIG_PATH))]
        config_path: PathBuf,

        /// Path to a file storing the last synchronized rustc commit.
        #[clap(long, default_value(DEFAULT_RUST_VERSION_PATH))]
        rust_version_path: PathBuf,

        /// Branch that should be pushed to your remote
        branch: String,

        /// Your GitHub usename where the fork is located
        username: String,

        /// Print executed commands.
        #[clap(long, short = 'v')]
        verbose: bool,
    },
```