### PR TITLE
always use stable Rust to build josh

### DIFF
--- a/src/josh.rs
+++ b/src/josh.rs
@@ -67,6 +67,7 @@ pub fn try_install_josh(verbose: bool) -> Option<JoshProxy> {
     run_command(
         &[
             "cargo",
+            "+stable",
             "install",
             "--locked",
             "--git",


### PR DESCRIPTION
I am not a huge fan of having josh installed automatically -- that's a global change to my system that IMO a tool shouldn't do without first asking me, and it makes it impossible to use the tool with a local, experimental version of josh (this `cargo install` will always downgrade it back to the released version). However, I am even more not a fan of having that build done with whatever random toolchain happens to be active when I invoke josh-sync. At the very least, let's make sure we use a stable version of Rust, not some nightly snapshot.