### PR TITLE
Use more qualified git ref when pushing branch to josh

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -321,7 +321,12 @@ After you fix the conflicts, `git add` the changes and run `git merge --continue
         // Do the actual push from the subtree git repo
         println!("Pushing changes...");
         run_command(
-            &["git", "push", &josh_url, &format!("HEAD:{branch}")],
+            &[
+                "git",
+                "push",
+                &josh_url,
+                &format!("HEAD:refs/heads/{branch}"),
+            ],
             self.verbose,
         )?;
         println!();


### PR DESCRIPTION
Trying if this fixes [this issue](https://github.com/rust-lang/rust/pull/149117#issuecomment-3555059359).
