### PR TITLE
Allow enabling verbose mode via JOSH_SYNC_VERBOSE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "rustc-josh-sync"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 directories = "6"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ on:
     # Run at 04:00 UTC every Monday and Thursday
     - cron: '0 4 * * 1,4'
 
+env:
+  # Optional to print detailed command logs
+  JOSH_SYNC_VERBOSE: true
+
 jobs:
   pull:
     uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@main

--- a/src/bin/rustc_josh_sync.rs
+++ b/src/bin/rustc_josh_sync.rs
@@ -50,7 +50,7 @@ enum Command {
         allow_noop: bool,
 
         /// Print executed commands.
-        #[clap(long, short = 'v')]
+        #[clap(long, short = 'v', env = "JOSH_SYNC_VERBOSE")]
         verbose: bool,
     },
     /// Push changes into the main `rust-lang/rust` repository `branch` of a `rustc` fork under
@@ -72,7 +72,7 @@ enum Command {
         username: String,
 
         /// Print executed commands.
-        #[clap(long, short = 'v')]
+        #[clap(long, short = 'v', env = "JOSH_SYNC_VERBOSE")]
         verbose: bool,
     },
 }


### PR DESCRIPTION
Make it easier to print verbose messages when using the action without needing a way to set per-command CLI arguments.