### PR TITLE
Bump `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -94,7 +94,7 @@ jobs:
 
           exit ${exitcode}
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ inputs.github-app-id }}


### PR DESCRIPTION
Fixes a Node deprecation warning.