### PR TITLE
Fix CI check

### DIFF
--- a/src/josh.rs
+++ b/src/josh.rs
@@ -88,6 +88,13 @@ impl JoshFilter {
 }
 
 fn josh_install_directory() -> PathBuf {
+    // Install binaries globally (into CARGO_HOME) on CI to ensure better (rust-)cache usage
+    if is_inside_ci()
+        && let Some(dirs) = directories::UserDirs::new()
+    {
+        return dirs.home_dir().join(".cargo");
+    }
+
     let Some(user_dirs) = directories::ProjectDirs::from("org", "rust-lang", "rustc-josh") else {
         eprintln!(
             "Cannot determine user directory for Josh installation, falling back to local directory"
@@ -134,12 +141,9 @@ fn try_install_josh_program(program: JoshProgram, verbose: bool) -> Option<PathB
         "https://github.com/josh-project/josh",
         "--tag",
         JOSH_VERSION,
+        "--root",
+        install_dir.to_str()?,
     ];
-
-    // Install binaries globally on CI to ensure better (rust-)cache usage
-    if !is_inside_ci() {
-        args.extend(["--root", install_dir.to_str()?]);
-    }
 
     args.push(krate);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -119,7 +119,7 @@ pub fn prompt(prompt: &str, default_response: bool) -> bool {
 }
 
 pub fn is_inside_ci() -> bool {
-    std::env::var("GITHUB_ACTIONS").as_deref() == Ok("1")
+    std::env::var("GITHUB_ACTIONS").as_deref() == Ok("true")
 }
 
 pub fn read_line() -> String {


### PR DESCRIPTION
It is `GITHUB_ACTIONS=true`, uhh. Not sure why this ever worked on CI. Either `gh` isn't available, or `read_line` somehow worked when the stdin was closed (but why would it be closed? :thinking:).